### PR TITLE
Case-sensitive lookup (#6) and ST2 compatibility

### DIFF
--- a/ReadmePlease.py
+++ b/ReadmePlease.py
@@ -1,7 +1,6 @@
 import sublime
 import sublime_plugin
 
-import os
 import sys
 
 # On Windows and OSX, with (commonly) case-insensitive file systems,
@@ -10,22 +9,6 @@ if sys.platform in ('win32', 'darwin'):
     README_PATTERNS = ['readme.*']
 else:
     README_PATTERNS = ["readme.*", "README.*", "Readme.*", "ReadMe.*"]
-
-
-try:
-    find_resources = sublime.find_resources
-except AttributeError:
-    import glob
-    def find_resources(pattern):
-        """ Fallback for ST2, where sublime.find_resources does not exist;
-            unlike the original, this function does only perform a NON-RECURSIVE
-            lookup inside sublime.packages_path(), which is all that's needed.
-        """
-        packages_path = sublime.packages_path()
-        base_path = os.path.dirname(packages_path)
-        path_pattern = os.path.join(packages_path, '*', pattern)
-        paths = glob.glob(path_pattern)
-        return (os.path.relpath(p, start=base_path) for p in paths)
 
 
 class ReadmePleaseCommand(sublime_plugin.WindowCommand):
@@ -38,8 +21,8 @@ class ReadmePleaseCommand(sublime_plugin.WindowCommand):
         self.helps = []
 
         for spelling in README_PATTERNS:
-            for path in find_resources(spelling):
-                components = path.split(os.path.sep)
+            for path in sublime.find_resources(spelling):
+                components = path.split('/')
                 if len(components) == 3:      # exclude files in package subdirs
                     package_name, readme_name = components[-2:]
                     self.helps.append([package_name, readme_name, path])


### PR DESCRIPTION
If no case-insensitive OS (Windows, OSX) is detected, try several common spellings to find readme files.

If `sublime.find_resources` is not defined (as in Sublime 2), use a fallback that mimicks the original behavior to the extent needed: look for files matching a pattern inside subdirectories of `sublime.packages_path()`. Unlike the original function, lookup is NOT recursive and does NOT include `sublime.installed_packages_path()`.

Tested on Linux Mint 16 with Sublime 2.0.2 and Sublime 3 (stable build 3059).

I noticed the script contains DOS/Windows line endings (CRLF), so I used them as well. You might want to check out this Github [article about line endings](https://help.github.com/articles/dealing-with-line-endings/#platform-all) to avoid confusion with people on other platforms.
